### PR TITLE
[OPS-4836] enable travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,30 @@
+language: php
+sudo: yes
+dist: trusty
+
+env:
+  - PHPVER="5.4.29"
+  - PHPVER="5.6.26"
+
+# This replaces the travis supplied phpbuild which defaults to ZTS enabled
+# builds.  Since we are replacing using the same config, we don't have to add
+# the env stuff.
+install:
+  - rm -rf ~/.phpenv
+  - sudo apt-get update
+  - sudo apt-get build-dep php5
+  - sudo apt-get install git libmcrypt-dev libreadline-dev
+  - curl -L http://git.io/phpenv-installer | bash
+  - travis_wait phpenv install "${PHPVER}"
+  - phpenv global "${PHPVER}"
+  - phpenv rehash
+
+before_script:
+  - php-config --extension-dir
+  - phpize
+  - ./configure
+  - make
+
+script:
+  - REPORT_EXIT_STATUS=1 NO_INTERACTION=1 make test
+

--- a/config.m4
+++ b/config.m4
@@ -6,6 +6,13 @@ dnl
 PHP_ARG_ENABLE(sugarcrm-basedir, Whether to enable the SugarCRM Basedir module,
 [ --enable-sugarcrm-basedir   Enable the SugarCRM Basedir module])
 
+AC_MSG_CHECKING([for no ZTS enabled])
+if test "$PHP_THREAD_SAFETY" == "yes" ; then
+	AC_MSG_ERROR([sugarcrm-basedir does not support ZTS, please re-compile PHP without ZTS enabled])
+else
+	AC_MSG_RESULT([ok])
+fi
+
 CFLAGS="$CFLAGS -Wall"
 
 if test "$PHP_ENABLE_SUGARCRM_BASEDIR" != "no"; then


### PR DESCRIPTION
Add travis support to basedir.  Since Travis ships a ZTS enabled php, we need to remove that and build our own non-ZTS version since we do not support ZTS at this time.

Also this specifically changes configure to check for ZTS and fail if detected.